### PR TITLE
scripts: clear the "ready" cache of all spinners before exporting

### DIFF
--- a/scripts/dist/index.min.js
+++ b/scripts/dist/index.min.js
@@ -1,35 +1,36 @@
 /* Copyright 2020 PingCAP, Inc. Licensed under MIT. */
 !function(){"use strict"
 const t={"en-US":{t:"Script failed to run. Please ensure it is running on the Grafana v6.x.x dashboard page.",
-s:"Going to export snapshot of the current dashboard: ",i:"Note: Only metrics from visible panels can be exported",
+i:"Going to export snapshot of the current dashboard: ",s:"Note: Only metrics from visible panels can be exported",
 o:"Number of panels",l:"Loading panels",h:"Expand all rows",p:"Export",u:"Export immediately",cancel:"Cancel"},"zh-TW":{
-t:"執行失敗。請確保是在 Grafana v6.x.x 的儀表板上執行劇本。",s:"即將匯出當前儀表板：",i:"注意：只能匯出已展開的面板內的資料",o:"面板數量",l:"載入面板中",h:"展開所有面板",p:"匯出",
-u:"立即匯出",cancel:"取消"},"zh-CN":{t:"执行失败。请确保是在 Grafana v6.x.x 的监控网页上执行脚本。",s:"将导出当前的监控页面：",i:"注意：只有已展开面板内的监控会被导出",
+t:"執行失敗。請確保是在 Grafana v6.x.x 的儀表板上執行劇本。",i:"即將匯出當前儀表板：",s:"注意：只能匯出已展開的面板內的資料",o:"面板數量",l:"載入面板中",h:"展開所有面板",p:"匯出",
+u:"立即匯出",cancel:"取消"},"zh-CN":{t:"执行失败。请确保是在 Grafana v6.x.x 的监控网页上执行脚本。",i:"将导出当前的监控页面：",s:"注意：只有已展开面板内的监控会被导出",
 o:"面板数量",l:"加载面板中",h:"展开所有面板",p:"导出",u:"立刻导出",cancel:"取消"}}[function(){const t=navigator.language
 return/^zh-/.test(t)?/\b(TW|HK|MO|Hant)\b/.test(t)?"zh-TW":"zh-CN":"en-US"}()]
 try{
-const e=angular.element,s=document.styleSheets[0],i=[".__dexport_hint{z-index:2222;position:fixed;background:#fff;color:#000;padding:1em;font-size:18px;border-left:3px solid #faad14;right:0;top:5em;opacity:.8;min-width:30em}",".__dexport_hint:hover{opacity:1}",".__dexport_hint button{margin:0 1em}",".__dexport_hint button[disabled]{opacity:.5}",".__dexport_hint progress{margin-right:1em;vertical-align:middle;width:18em}"]
+const e=angular.element,i=document.styleSheets[0],s=[".__dexport_hint{z-index:2222;position:fixed;background:#fff;color:#000;padding:1em;font-size:18px;border-left:3px solid #faad14;right:0;top:5em;opacity:.8;min-width:30em}",".__dexport_hint:hover{opacity:1}",".__dexport_hint button{margin:0 1em}",".__dexport_hint button[disabled]{opacity:.5}",".__dexport_hint progress{margin-right:1em;vertical-align:middle;width:18em}"]
 class n{constructor(){const n=e(document).injector()
 this.m=n.get("timeSrv")
 const o=this.m.dashboard
-i.forEach(t=>s.insertRule(t,0)),this.g=e("<span>"),this._=e('<progress value="0">'),
+s.forEach(t=>i.insertRule(t,0)),this.g=e("<span>"),this._=e('<progress value="0">'),
 this.v=e('<button style="font-weight:bold">').text(t.p).one("click",()=>this.P()),
 this.S=e("<button>").text(t.h).on("click",()=>o.expandRows())
 const a=/^(Mac|iP)/.test(navigator.platform)?"flex-direction:row-reverse":"justify-content:center"
-this.$=e('<div class="__dexport_hint">').append(e("<p>").text(t.s).append(e("<strong>").text(o.title)),e("<p>").text(t.i).append(this.S),e('<p style="font-size:.8em">').append(this._,this.g),e(`<p style="display:flex;${a}">`).append(this.v,e("<button>").text(t.cancel).on("click",()=>this.T()))),
-this.I=0,e(document.body).append(this.$),this.O=setInterval(()=>this.k(),500)}k(){const s=e(".panel-loading"),i=s.length
-if(0===this.I)this.g.text(`${t.o}: ${i}`),this.v.prop("disabled",0===i)
-else{const e=s.filter(".ng-hide").length,n=(100*e/i||0).toFixed(1)
-this.g.text(`${t.l}: ${n}% (${e}/${i})`),this._.prop({value:e,max:i}),i>e?2!==this.I&&(this.I=2,
+this.$=e('<div class="__dexport_hint">').append(e("<p>").text(t.i).append(e("<strong>").text(o.title)),e("<p>").text(t.s).append(this.S),e('<p style="font-size:.8em">').append(this._,this.g),e(`<p style="display:flex;${a}">`).append(this.v,e("<button>").text(t.cancel).on("click",()=>this.T()))),
+this.I=0,e(document.body).append(this.$),this.O=setInterval(()=>this.k(),500)}k(){const i=e(".panel-loading"),s=i.length
+if(0===this.I)this.g.text(`${t.o}: ${s}`),this.v.prop("disabled",0===s)
+else{const e=i.filter(".ng-hide").length,n=(100*e/s||0).toFixed(1)
+this.g.text(`${t.l}: ${n}% (${e}/${s})`),this._.prop({value:e,max:s}),s>e?2!==this.I&&(this.I=2,
 this.v.prop("disabled",!1).text(t.u).one("click",()=>this.N())):this.N()}}P(){const t=this.m.dashboard
-this.I=1,this.v.prop("disabled",!0),this.U=t.refresh,this.m.setAutoRefresh(),t.snapshot={timestamp:new Date},
-t.startRefresh()}N(){const t=this.m.dashboard,s=t.snapshot.timestamp.toISOString(),i=t.getSaveModelClone()
-i.time=this.m.timeRange()
-const n={meta:{isSnapshot:!0,type:"snapshot",expires:"9999-12-31T23:59:59Z",created:s},dashboard:i}
+this.I=1,this.v.prop("disabled",!0),this.U=t.refresh,this.m.setAutoRefresh(),e(".panel-loading").removeClass("ng-hide"),
+t.snapshot={timestamp:new Date},t.startRefresh()}N(){
+const t=this.m.dashboard,i=t.snapshot.timestamp.toISOString(),s=t.getSaveModelClone()
+s.time=this.m.timeRange()
+const n={meta:{isSnapshot:!0,type:"snapshot",expires:"9999-12-31T23:59:59Z",created:i},dashboard:s}
 this.T()
 const o=new Blob([JSON.stringify(n)],{type:"application/json"}),a=URL.createObjectURL(o),r=e("<a>")
-r.prop({href:a,download:`${i.title}_${s}.json`}),e(document.body).append(r),r[0].click(),setTimeout(()=>{
+r.prop({href:a,download:`${s.title}_${i}.json`}),e(document.body).append(r),r[0].click(),setTimeout(()=>{
 URL.revokeObjectURL(a),r.remove()},0)}T(){const t=this.m.dashboard
 delete t.snapshot,t.forEachPanel(t=>delete t.snapshotData),t.annotations.list.forEach(t=>delete t.snapshotData),
-this.U&&this.m.setAutoRefresh(this.U),clearInterval(this.O),this.$.remove(),i.forEach(()=>s.deleteRule(0))}}new n
+this.U&&this.m.setAutoRefresh(this.U),clearInterval(this.O),this.$.remove(),s.forEach(()=>i.deleteRule(0))}}new n
 }catch(e){console.error(e),alert(t.t)}}()

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -97,6 +97,9 @@ try {
             this.oldRefreshRate = dashboard.refresh;
             this.timeSrv.setAutoRefresh();
 
+            // remove the "ready" status of all spinners
+            $('.panel-loading').removeClass('ng-hide');
+
             dashboard.snapshot = {timestamp: new Date()};
             dashboard.startRefresh();
         }

--- a/scripts/terser.json
+++ b/scripts/terser.json
@@ -19,6 +19,7 @@
         "on",
         "one",
         "prop",
+        "removeClass",
         "setAutoRefresh",
         "snapshot",
         "snapshotData",


### PR DESCRIPTION
this avoids "export" immediately finishes without any snapshot data.